### PR TITLE
Fix module path for FastAPI app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Projektdateien kopieren
-COPY app/ ./app/
+COPY app/ .
 
 # Expose für FastAPI
 EXPOSE 8000
 
 # Startbefehl für FastAPI
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/app/main.py
+++ b/app/main.py
@@ -9,9 +9,9 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from dotenv import load_dotenv
 
-from app.value import DailyBrief
-from app.prompt import PromptManager
-from app.src.knowledge_scraper import KnowledgeScraper
+from src.value import DailyBrief
+from src.prompt import PromptManager
+from src.knowledge_scraper import KnowledgeScraper
 
 # -------------------------------------------------------
 # 1️⃣ ENV & CONFIG
@@ -21,16 +21,16 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if not OPENAI_API_KEY:
     print("❌ WARNUNG: Kein OPENAI_API_KEY in .env gefunden!")
 
-INTERESTS_FILE = "app/interests.json"
-PROMPT_FILE = "app/prompt.yml"
+INTERESTS_FILE = "interests.json"
+PROMPT_FILE = "prompt.yml"
 
 # PromptManager initialisieren (falls du noch interne Prompts nutzt)
 prompt_manager = PromptManager(PROMPT_FILE)
 
 # FastAPI Setup
 app = FastAPI()
-templates = Jinja2Templates(directory="app/templates")
-app.mount("/static", StaticFiles(directory="app/static"), name="static")
+templates = Jinja2Templates(directory="templates")
+app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
 # -------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix Dockerfile to copy app source to workdir and start uvicorn with `main:app`
- adjust imports and paths in main FastAPI entrypoint
- include static directory placeholder for static files

## Testing
- `python -m uvicorn main:app --host 127.0.0.1 --port 8000 --reload --reload-dir . > /tmp/uvicorn.log`


------
https://chatgpt.com/codex/tasks/task_e_688e8d2c1d0c83328fc55e14856ca691